### PR TITLE
Don’t autoupgrade to PromiseKit 2.0

### DIFF
--- a/NLAutomatic.podspec
+++ b/NLAutomatic.podspec
@@ -24,6 +24,6 @@ Pod::Spec.new do |s|
   s.subspec 'Promise' do |sub|
     sub.source_files = 'Classes/Promise/*.{h,m}'
     sub.dependency 'NLAutomatic/Adapter'
-    sub.dependency 'PromiseKit/Promise'
+    sub.dependency 'PromiseKit/Promise', '~> 1.5'
   end
 end


### PR DESCRIPTION
When PromiseKit 2 is released (soon {ish}) it would be better you check everything is good in your pod spec rather than have users get auto-upgraded. This dependency modifier will ensure your users will not upgrade before you have checked everything is good. x
